### PR TITLE
Use Hey world for blog posts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@ Menus:
     - identifier: blog
       name: Blog
       title: Blog posts
-      url: /blogs
+      url: https://world.hey.com/victorbogo
       weight: 1
 
 params:

--- a/content/blogs/first.md
+++ b/content/blogs/first.md
@@ -1,1 +1,0 @@
-# This is the first post


### PR DESCRIPTION
Use Hey world for blog posts instead of the built-in markdown-based blog posts functionality. I decided to use Hey as it already provided subscription functionality and is simple enough to facilitate the process of writing new content.